### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ awful.screen.connect_for_each_screen(function(s)
 
     s.mytaglist = awful.widget.taglist({
        screen = s,
+       filter  = awful.widget.taglist.filter.all,
        buttons = taglist_buttons,
        source = function(screen, args) return tags end,
     })


### PR DESCRIPTION
Debian unstable linux distribution, awesome 4.3 (4.3-5+b2 Debian verision)
Following the usage in upstream's README.md, I lost the clickable taglist on each screen. Including the filter statement brought it back.