### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ end
 -- ensure that removing screens doesn't kill tags
 tag.connect_signal("request::screen", function(t)
     t.selected = false
-    for s in capi.screen do
+    for s in screen do
         if s ~= t.screen then
             t.screen = s
             return


### PR DESCRIPTION
Hello and good day, good sir. I absolutely love this code you have made as I love this way of handling multi monitors and have been using it since I started using awesome, pretty much. But one thing that always bugged me was that piece of code in the README teaching about how to ensure removing screens would not kill tags.

The code snippet in the README uses a variable named "capi", which is not defined anywhere, so pretty much every time I disconnected my second monitor, awesome would raise an error about the variable "capi" being nil.

What I have always done was to just reset awesome every time this happened, even automated the reset, but this did not look right. So today I decided to look at the code. I know very little about awesome's modules and apis, so I was still a little bit confused. I looked at your dotfiles repo and found out you were defining capi before like this: `capi = { screen = screen }`. So I figured that I could also do it, or just iterate over `screen` directly, since the for loop was for `capi.screen`. Since I don't use `capi` anywhere else, I thought this was better than defining this variable.

After doing this, the errors really stopped appearing when I disconnect my second monitor. I hope this is right? If it is, I think we could update the README so other people can avoid it as well.

Thanks again for this awesome library, I love it very much! (: