### PR TITLE
Fix issue where multiple tags are selected after calling `swap_screen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ awful.screen.connect_for_each_screen(function(s)
          end
     end
 
-    -- create a special scratch tag for double buffering
-    s.scratch = awful.tag.add('scratch-' .. s.index, {})
-
     s.mytaglist = awful.widget.taglist({
        screen = s,
        filter  = awful.widget.taglist.filter.all,

--- a/init.lua
+++ b/init.lua
@@ -128,23 +128,33 @@ function sharetags.toggle_tag(t, screen)
     end
 end
 
-
--- Swap all tags between two screens
+-- Swap all selected tags between two screens
 function sharetags.swap_screen(s1, s2)
     if #s1.selected_tags ~= 1 or #s2.selected_tags ~= 1 then
-        print("can't swap multiple tags yet")
+        print("can't swap multiple selected tags yet")
     end
 
     local t1 = s1.selected_tag
     local t2 = s2.selected_tag
 
     -- hide both tags in scratch space
-    t1:swap(s1.scratch)
-    t2:swap(s2.scratch)
+    t1:swap(t2)
 
-    -- bring tabs back but to alternate screends
-    t2:swap(s1.scratch)
-    t1:swap(s2.scratch)
+    -- Set selected in both screens to the correct count
+    if #s1.selected_tags ~= 1 then
+        for _, t in ipairs(s1.selected_tags) do
+            t.selected = false
+        end
+    end
+
+    if #s2.selected_tags ~= 1 then
+        for _, t in ipairs(s2.selected_tags) do
+            t.selected = false
+        end
+    end
+
+    t1.selected = true
+    t2.selected = true
 end
 
 return sharetags

--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,7 @@ function sharetags.create_tags(names, layouts)
         tags[tagnumber].number = tagnumber
 
         awful.layout.set(layouts[tagnumber], tags[tagnumber])
-     end
+    end
     return tags
 end
 --}}}
@@ -112,7 +112,7 @@ function sharetags.select_tag(t, target_screen)
     -- If there was a moving tag then the focus on the window is lost.  Checking
     -- if this is the same tag and thus restore focus on the window
     if is_tag_moved and is_tag_select and #t:clients() > 0 and prev_focus then
-       capi.client.focus = prev_focus
+        capi.client.focus = prev_focus
     end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -39,20 +39,20 @@ end
 --{{{ sharetags.tag_move: move a tag to a screen
 -- @param t : the tag object to move
 -- @param screen_target : the screen object to move to
-function sharetags.tag_move(t, screen_target)
+function sharetags.tag_move(t, target_screen)
     local ts = t or tag.selected()
 
-    if not screen_target then return end
+    if not target_screen then return end
 
     local current_screen = ts.screen
 
-    if current_screen and screen_target ~= current_screen then
+    if current_screen and target_screen ~= current_screen then
         -- switch for tag
         local mynumber = ts.number
 
         -- sort tags
-        local index = #screen_target.tags+1
-        for i, screen_tag in pairs(screen_target.tags) do
+        local index = #target_screen.tags + 1
+        for i, screen_tag in pairs(target_screen.tags) do
             local number = screen_tag.number
             if number ~= nil and mynumber < number then
                 index = i
@@ -72,9 +72,9 @@ function sharetags.tag_move(t, screen_target)
 
         -- switch for all clients on tag
         if #ts:clients() > 0 then
-            for _ , c in ipairs(ts:clients()) do
+            for _, c in ipairs(ts:clients()) do
                 if not c.sticky then
-                    c.screen = screen_target
+                    c.screen = target_screen
                     c:tags({ ts })
 
                     -- Fix maximized client if display sizes not equal


### PR DESCRIPTION
Hi,

I noticed an issue where sometimes when a two tags are swapped, unrelated tags on both screen became selected. So I have rewrote the `swap_screen` function to:

1. Reset the selection to only the swapped tags
2. Avoid using the scratch tag for swapping since that didn't seem necessary from my testing. 

I have also took the liberty of renaming the `screen_target` argument of `tag_move` to `target_screen` so that it matches the rest of the code.
